### PR TITLE
postgress persistent volume

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -33,8 +33,11 @@ services:
       POSTGRES_USER : "servicebot_u"
       POSTGRES_PASSWORD : "secret_doggo"
       POSTGRES_DB : "sb_db"
+    volumes:
+      - db-data:/var/lib/postgresql/data
     expose:
       - "5432"
 volumes:
   upload-data:
   environment-file:
+  db-data:


### PR DESCRIPTION
Add a docker volume to make the postgres database persistent between down, up.
Helps during testing.